### PR TITLE
use DOMUtils's new pseudo-class lock API for locking pseudo-classes

### DIFF
--- a/extension/content/firebug/css/cssElementPanel.js
+++ b/extension/content/firebug/css/cssElementPanel.js
@@ -492,33 +492,45 @@ CSSElementPanel.prototype = Obj.extend(CSSStyleSheetPanel.prototype,
 
         if (Dom.domUtils && this.selection)
         {
-            var state = safeGetContentState(this.selection);
             var self = this;
 
             ret.push("-");
 
             ret.push(
                 {
-                    label: "style.option.label.active",
+                    label: "style.option.label.hover",
                     type: "checkbox",
-                    checked: state & STATE_ACTIVE,
-                    tooltiptext: "style.option.tip.active",
+                    checked: self.hasPseudoClassLock(":hover"),
+                    tooltiptext: "style.option.tip.hover",
                     command: function()
                     {
-                        self.updateContentState(STATE_ACTIVE, !this.getAttribute("checked"));
+                        self.togglePseudoClassLock(":hover");
                     }
                 }
             );
 
             ret.push(
                 {
-                    label: "style.option.label.hover",
+                    label: "style.option.label.active",
                     type: "checkbox",
-                    checked: state & STATE_HOVER,
-                    tooltiptext: "style.option.tip.hover",
+                    checked: self.hasPseudoClassLock(":active"),
+                    tooltiptext: "style.option.tip.active",
                     command: function()
                     {
-                        self.updateContentState(STATE_HOVER, !this.getAttribute("checked"));
+                        self.togglePseudoClassLock(":active");
+                    }
+                }
+            );
+   
+            ret.push(
+                {
+                    label: "style.option.label.focus",
+                    type: "checkbox",
+                    checked: self.hasPseudoClassLock(":focus"),
+                    tooltiptext: "style.option.tip.focus",
+                    command: function()
+                    {
+                        self.togglePseudoClassLock(":focus");
                     }
                 }
             );
@@ -527,15 +539,27 @@ CSSElementPanel.prototype = Obj.extend(CSSStyleSheetPanel.prototype,
         return ret;
     },
 
-    updateContentState: function(state, remove)
+    hasPseudoClassLock: function(pseudoClass)
+    {
+        return Dom.domUtils.hasPseudoClassLock(this.selection, pseudoClass);
+    },
+
+    togglePseudoClassLock: function(pseudoClass)
     {
         if (FBTrace.DBG_CSS)
-            FBTrace.sysout("css.updateContentState; state: " + state + ", remove: " + remove);
+            FBTrace.sysout("css.togglePseudoClassLock; pseudo-class: " + pseudoClass);
 
-        Dom.domUtils.setContentState(remove ? this.selection.ownerDocument.documentElement :
-            this.selection, state);
+        if (Dom.domUtils.hasPseudoClassLock(this.selection, pseudoClass))
+            Dom.domUtils.removePseudoClassLock(this.selection, pseudoClass);
+        else
+            Dom.domUtils.addPseudoClassLock(this.selection, pseudoClass);
 
         this.refresh();
+    },
+
+    clearPseudoClassLocks: function()
+    {
+        Dom.domUtils.clearPseudoClassLocks(this.selection);
     },
 
     addStateChangeHandlers: function(el)

--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -494,6 +494,13 @@ style.option.tip.active=Display :active pseudo-class styles
 style.option.label.hover=:hover
 style.option.tip.hover=Display :hover pseudo-class styles
 
+# LOCALIZATION NOTE (style.option.tip.focus):
+# Style side panel option tooltip (located in tab's option menu). If the option is set to true,
+# the Style side panel will simulate the element being focused and therefore display
+# :focus pseudo-class styles
+style.option.label.focus=:focus
+style.option.tip.focus=Display :focus pseudo-class styles
+
 # LOCALIZATION NOTE (css.option.Expand_Shorthand_Properties, css.option.tip.Expand_Shorthand_Properties):
 # CSS panel/Style side panel option (located in tab's option menu). If set to true,
 # CSS shorthand properties like 'margin' will be split into their components, e.g. 'margin-top',


### PR DESCRIPTION
This uses the new DOMUtils pseudo-class lock API from [bug 708874](https://bugzilla.mozilla.org/show_bug.cgi?id=708874) to toggle `:hover`, `:active`, and `:focus` on the CSS panel.

This is preferable to what Firebug currently has because setting these locks doesn't update the element's actual content state, rather it just updates the element's style. So mousing over another element doesn't lose the `:hover`, etc.

I can't figure out how to listen for when a new element is selected and listen for when Firebug is closed from the CSS panel. So right now the pseudo-class stays on the element until you manually uncheck it.
