### PR TITLE
Use displayName instead of "function()" and "anonymous"?

### DIFF
--- a/extension/content/firebug/chrome/reps.js
+++ b/extension/content/firebug/chrome/reps.js
@@ -213,7 +213,8 @@ FirebugReps.Func = domplate(Firebug.Rep,
         var fnText = Str.safeToString(fn);
         var namedFn = /^function ([^(]+\([^)]*\)) \{/.exec(fnText);
         var anonFn  = /^function \(/.test(fnText);
-        return namedFn ? namedFn[1] : (anonFn ? "function()" : fnText);
+        var displayName = fn.displayName;
+        return namedFn ? namedFn[1] : (displayName ? displayName + "()": (anonFn ? "function()" : fnText));
     },
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/extension/content/firebug/chrome/reps.js
+++ b/extension/content/firebug/chrome/reps.js
@@ -214,7 +214,9 @@ FirebugReps.Func = domplate(Firebug.Rep,
         var namedFn = /^function ([^(]+\([^)]*\)) \{/.exec(fnText);
         var anonFn  = /^function \(/.test(fnText);
         var displayName = fn.displayName;
-        return namedFn ? namedFn[1] : (displayName ? displayName + "()": (anonFn ? "function()" : fnText));
+
+        return namedFn ? namedFn[1] : (displayName ? displayName + "()" :
+            (anonFn ? "function()" : fnText));
     },
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/extension/content/firebug/js/stackFrame.js
+++ b/extension/content/firebug/js/stackFrame.js
@@ -573,7 +573,7 @@ StackFrame.getDisplayName = function(scope, script)
             return Wrapper.unwrapIValue(scope).arguments.callee.displayName;
         else if (script) {
             var fnObj = Wrapper.unwrapIValue(script.functionObject);
-            return fnObj.displayName ? fnObj.displayName : script.functionName;
+            return (fnObj && fnObj.displayName) ? fnObj.displayName : script.functionName;
         }
     }
     catch (err)

--- a/extension/content/firebug/js/stackFrame.js
+++ b/extension/content/firebug/js/stackFrame.js
@@ -571,8 +571,10 @@ StackFrame.getDisplayName = function(scope, script)
     {
         if (scope)
             return Wrapper.unwrapIValue(scope).arguments.callee.displayName;
-        else if (script)
-            return script.functionName;
+        else if (script) {
+            var fnObj = Wrapper.unwrapIValue(script.functionObject);
+            return fnObj.displayName ? fnObj.displayName : script.functionName;
+        }
     }
     catch (err)
     {


### PR DESCRIPTION
Firebug already supports displayName in debugger. Why not use it in console and profiler report too? 
http://dl.dropbox.com/u/1645803/after.png looks much more clear than http://dl.dropbox.com/u/1645803/before.png
