### PR TITLE
allow defaults/preferences files to be loaded from XPI (non-directory) installs

### DIFF
--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -20,7 +20,8 @@ var FIREBUG_MODULES = [
     "resource://firebug/observer-service.js",
     "resource://firebug/require-debug.js",
     "resource://firebug/require.js",
-    "resource://firebug/storageService.js"
+    "resource://firebug/storageService.js",
+    "resource://firebug/prefLoader.js"
 ];
 
 Cu.import("resource://gre/modules/Services.jsm");

--- a/extension/modules/prefLoader.js
+++ b/extension/modules/prefLoader.js
@@ -34,7 +34,7 @@ function loadDefaultPrefs(path, fileName)
         if (path.isDirectory())
             uri = Services.io.newURI("defaults/preferences/" + fileName, null, baseURI).spec;
         else
-            uri = "jar:" + baseURI.spec + "!/defaults/preferences/prefs.js";
+            uri = "jar:" + baseURI.spec + "!/defaults/preferences/" + fileName;
 
         // Load preference file and use 'pref' function to define all prefs.
         Services.scriptloader.loadSubScript(uri, {pref: pref});


### PR DESCRIPTION
...rather than falling back to a single hardcoded "!/defaults/preferences/prefs.js"
