### PR TITLE
Issue 5221: 	Can't debug code made with console of FB 1.9 but can do it in <1.8

### DIFF
--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -44,6 +44,8 @@ function startup(params, reason)
     var resourceURI = Services.io.newURI(__SCRIPT_URI_SPEC__ + "/../modules/", null, null);
     res.setSubstitution("firebug", resourceURI);
     res.setSubstitution("moduleloader", resourceURI);
+    resourceURI = Services.io.newURI(__SCRIPT_URI_SPEC__ + "/../content/firebug/", null, null);
+    res.setSubstitution("firebug_rjs", resourceURI);
 
     // Add our chrome registration. not needed for 10+
     Components.manager.addBootstrappedManifestLocation(params.installPath);
@@ -108,6 +110,7 @@ function shutdown(params, reason)
     var res = Services.io.getProtocolHandler("resource").QueryInterface(Ci.nsIResProtocolHandler);
     res.setSubstitution("firebug", null);
     res.setSubstitution("moduleloader", null);
+    res.setSubstitution("firebug_rjs", null);
 }
 
 // ********************************************************************************************* //

--- a/extension/content/firebug/moduleConfig.js
+++ b/extension/content/firebug/moduleConfig.js
@@ -19,11 +19,11 @@ Firebug.getModuleLoaderConfig = function(baseConfig)
     baseConfig.prefDomain = baseConfig.prefDomain || "extensions.firebug";
     baseConfig.baseUrl = baseConfig.baseUrl || "resource://";
     baseConfig.xhtml = true;  // createElementNS used
-    baseConfig.arch = baseConfig.arch || "chrome://firebug/content/bti/inProcess";
+    baseConfig.arch = baseConfig.arch || "firebug_rjs/bti/inProcess";
 
     baseConfig.paths = baseConfig.paths || {
         "arch": baseConfig.arch,
-        "firebug": "chrome://firebug/content"
+        "firebug": "firebug_rjs"
     };
 
     var config = {};


### PR DESCRIPTION
this brings back firebug_rjs for http://code.google.com/p/fbug/issues/detail?id=5221
