### PR TITLE
Necessary changes related to the Issue 5526

### DIFF
--- a/extension/content/firebug/firebug.js
+++ b/extension/content/firebug/firebug.js
@@ -797,14 +797,16 @@ window.Firebug =
                 Firebug.minimizeBar();
             }
         }
-        else if (Firebug.framePosition == "detached")
-        {
-            this.detachBar();
-        }
         // toggle minimize
         else if (Firebug.isMinimized())
         {
-            Firebug.unMinimize();
+            // be careful, unMinimize func always sets placement to
+            // inbrowser first then unminimizes. when we want to
+            // unminimize in detached mode must call detachBar func.
+            if(Firebug.framePosition == "detached")
+                this.detachBar();
+            else
+                Firebug.unMinimize();
         }
         // else isInBrowser
         else if (!forceOpen)
@@ -840,10 +842,20 @@ window.Firebug =
 
     minimizeBar: function()  // just pull down the UI, but don't deactivate the context
     {
-        if (Firebug.isDetached())  // TODO disable minimize on externalMode
+        if (Firebug.isDetached())
         {
             // TODO reattach
-            Firebug.toggleDetachBar(false, false);
+
+            // window is closing in detached mode
+            if(Firebug.chrome.window.top)
+            {
+                topWindow = Firebug.chrome.window.top;
+                topWindow.exportFirebug();
+                topWindow.close();
+            }
+
+            Firebug.setPlacement("minimized");
+            this.showBar(false);
             Firebug.chrome.focus();
         }
         else // inBrowser -> minimized
@@ -873,7 +885,8 @@ window.Firebug =
     // detached -> closed; inBrowser -> detached TODO reattach
     toggleDetachBar: function(forceOpen, reopenInBrowser)
     {
-        if (!forceOpen && Firebug.isDetached())  // detached -> minimized
+        //detached -> inbrowser
+        if (!forceOpen && Firebug.isDetached())
         {
             var topWin = Firebug.chrome.window.top;
             topWin.exportFirebug();
@@ -885,6 +898,14 @@ window.Firebug =
                 Firebug.minimizeBar();
             Firebug.chrome.syncPositionPref();
         }
+        // is minimized now but the last time that has been closed, was in detached mode,
+        // so it should be returned to in browser mode because the user has pressed CTRL+F12.
+        else if (Firebug.framePosition == "detached" && Firebug.isMinimized())
+        {
+            Firebug.unMinimize();
+            Firebug.chrome.syncPositionPref();
+        }
+        // else is in browser mode, then switch to detached mode
         else
         {
             this.detachBar();

--- a/extension/content/firebug/firebug.js
+++ b/extension/content/firebug/firebug.js
@@ -789,7 +789,7 @@ window.Firebug =
 
         if (Firebug.isDetached())
         {
-            if( !Firebug.chrome.hasFocus() || forceOpen)
+            if ( !Firebug.chrome.hasFocus() || forceOpen)
             {
                 Firebug.chrome.focus();
             } else
@@ -803,7 +803,7 @@ window.Firebug =
             // be careful, unMinimize func always sets placement to
             // inbrowser first then unminimizes. when we want to
             // unminimize in detached mode must call detachBar func.
-            if(Firebug.framePosition == "detached")
+            if (Firebug.framePosition == "detached")
                 this.detachBar();
             else
                 Firebug.unMinimize();
@@ -847,7 +847,7 @@ window.Firebug =
             // TODO reattach
 
             // window is closing in detached mode
-            if(Firebug.chrome.window.top)
+            if (Firebug.chrome.window.top)
             {
                 topWindow = Firebug.chrome.window.top;
                 topWindow.exportFirebug();
@@ -933,7 +933,7 @@ window.Firebug =
             return null;
         }
 
-        if(Firebug.chrome.waitingForDetach)
+        if (Firebug.chrome.waitingForDetach)
             return null;
         Firebug.chrome.waitingForDetach = true;
 


### PR DESCRIPTION
When firebug in detached mode is minimized , will open in detached mode again.

If the user presses CTRL+F12 after firebug has lost focus: switchs to inbrowser mode, then focuse.  F12 works as before (firebug is focused).

If firebug is closed in detached mode and user presses CTRL+F12 then firebug mode is changed to inbrowser then is opened and vice versa.

The last two options is added because it seems to be true. let me know if you think it is wrong.
