### PR TITLE
Remove some duplicated strings

### DIFF
--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -1231,7 +1231,6 @@ a11y.layout.left=left
 a11y.layout.width=width
 a11y.layout.height=height
 a11y.layout.size=size
-a11y.layout.position=position
 a11y.layout.z-index=z-index
 a11y.layout.box-sizing=box-sizing
 a11y.layout.clientBoundingRect=bounding client rect
@@ -1421,12 +1420,6 @@ script.suggestion.no_system_source_debugging=Firebug currently can't be used to 
 script.warning.no_javascript=No Javascript on this page
 script.suggestion.no_javascript2=If <script> tags have a "type" attribute, it should equal "text/javascript" or "application/javascript". Also scripts must be parsable (syntactically correct).
 
-# LOCALIZATION NOTE (script.warning.no_chrome_debugging, script.suggestion.no_chrome_debugging):
-# Message displayed in the Script panel, if the page opened is accessed via a chrome URL.
-# The suggestion message represents an advice how to solve the problem.
-script.warning.no_system_source_debugging=System sources can't be debugged
-script.suggestion.no_system_source_debugging=Firebug currently can't be used to debug system sources. See <a>issue 5110</a> for the reason.
-
 # LOCALIZATION NOTE (script.warning.debugger_active, script.suggestion.debugger_active):
 # Message displayed in the Script panel, if the page is opened in different tabs/windows and
 # the debugger is already halted at a breakpoint inside another tab/window.
@@ -1545,7 +1538,7 @@ firebug.activation.privateBrowsingMode=Sites are not remembered in Private Brows
 # Label used within Script panel's options menu. Represents an option, that can be used
 # to switch of the break notifications.
 firebug.breakpoint.showBreakNotifications=Show Break Notifications
-firebug.breakpoint.tip.Show_Break_Notifications=Show a notification box, when a Break On ... feature or the debugger; keyword stopped the JavaScript execution 
+firebug.breakpoint.tip.Show_Break_Notifications=Show a notification box, when a Break On ... feature or the debugger; keyword stopped the JavaScript execution
 
 # LOCALIZATION NOTE (firebug.activation.privateBrowsingMode):
 # Message displayed in a break notification popup next to a checkbox.


### PR DESCRIPTION
Just some duplication I found in firebug.properties, One trailing whitespace also removed by my editor

FYI: In 72e5999e, "Refresh" is changed to "panel.Refresh" in js but not firebug.properties, not sure how you'd like to fix this.
