### PR TITLE
Making firebug's Style Side Panel aware of less css debug info (applicable to Sass too with minor tweak)

### DIFF
--- a/extension/content/firebug/css/cssPanel.js
+++ b/extension/content/firebug/css/cssPanel.js
@@ -1457,13 +1457,13 @@ Firebug.CSSStyleSheetPanel.prototype = Obj.extend(Firebug.Panel,
             href = element.ownerDocument.location.href;
         
         if (href.indexOf('.less') !== -1) {                                     // if this is a less file
-            var doc = Css.getDocumentForStyleSheet(rule.parentStyleSheet), 
-                styleSheet = doc ? doc.styleSheets[instance] : null;
+            var oDoc = Css.getDocumentForStyleSheet(rule.parentStyleSheet), 
+                oStyleSheet = oDoc ? oDoc.styleSheets[instance] : null;
             
-            if(styleSheet && this.context.sourceCache) {
+            if(oStyleSheet && this.context.sourceCache) {
                 var regExDotLess = /\/\* ([^:]*):L(\d*) \*\//                   // regex for parsing dotLess Comments. format:  /* /path/css-file.less:L123 */
                     , iLineIndex = line-1                                       // a counter for the current line index
-                    , arrCss = this.context.sourceCache.load(styleSheet.href);  // handle to the css doc, type = array of text strings per line                
+                    , arrCss = this.context.sourceCache.load(oStyleSheet.href); // handle to the css doc, type = array of text strings per line                
                 
                 while(iLineIndex >= 0 && line - iLineIndex < 5) {               // prevent index out of bounds and stop looking after 5 lines
                     if (regExDotLess.test(arrCss[iLineIndex])) {

--- a/trace/FBTrace/chrome/firebug/content/css/cssPanel.js
+++ b/trace/FBTrace/chrome/firebug/content/css/cssPanel.js
@@ -1375,14 +1375,35 @@ Firebug.CSSStyleSheetPanel.prototype = Obj.extend(Firebug.Panel,
     getSourceLink: function(target, rule)
     {
         var element = rule.parentStyleSheet.ownerNode;
+        var line = getRuleLine(rule);
+        var instance = Css.getInstanceForStyleSheet(rule.parentStyleSheet);
         var href = rule.parentStyleSheet.href;  // Null means inline
 
         // http://code.google.com/p/fbug/issues/detail?id=452
         if (!href)
             href = element.ownerDocument.location.href;
+        
+        if (href.indexOf('.less') !== -1) {                                     // if this is a less file
+            var oDoc = Css.getDocumentForStyleSheet(rule.parentStyleSheet), 
+                oStyleSheet = oDoc ? oDoc.styleSheets[instance] : null;
+            
+            if(oStyleSheet && this.context.sourceCache) {
+                var regExDotLess = /\/\* ([^:]*):L(\d*) \*\//                   // regex for parsing dotLess Comments. format:  /* /path/css-file.less:L123 */
+                    , iLineIndex = line-1                                       // a counter for the current line index
+                    , arrCss = this.context.sourceCache.load(oStyleSheet.href); // handle to the css doc, type = array of text strings per line                
+                
+                while(iLineIndex >= 0 && line - iLineIndex < 5) {               // prevent index out of bounds and stop looking after 5 lines
+                    if (regExDotLess.test(arrCss[iLineIndex])) {
+                        var arrMatch = arrCss[iLineIndex].match(regExDotLess);  
+                        href = arrMatch[1];                                     // Update the handle to the file 
+                        line = arrMatch[2];                                     // and the line based on the comment 
+                        break;   
+                    }
+                    iLineIndex -= 1;
+                }
+            }
+        }
 
-        var line = getRuleLine(rule);
-        var instance = Css.getInstanceForStyleSheet(rule.parentStyleSheet);
         var sourceLink = new SourceLink.SourceLink(href, line, "css", rule, instance);
 
         return sourceLink;


### PR DESCRIPTION
With the increasing popularity of CSS coding frameworks like less & Sass, the CSS wilderness is a changing.  At its simplest level, these frameworks offer bundling of files (many CSS files into 1) to limit HTTP requests for more responsive online applications.

This causes a serious headache for developers when using firebug, as it is reporting the file name and line number in the bundled file (Note: This is accurate from the client side perspective, but it makes development difficult).  On the server side however, the actual rule could be in one of many files, and even when the file name is correct, the line line numbers are inaccurate due to the server side importing of the other CSS files.

However, these frameworks provide an option to output a /\* CSS Comment */ including the original line number and file name where the rule is declared, removing the confusion.

This pull request simply sniffs for a .less file and parses the comment if it finds one. Else, it doesn't touch anything. The footprint for this is very small (21 lines of code) and I attempted to use the existing source cache to make this a near zero-impact addition to an already amazing plugin.

The work done here could also be expanded to work for the Sass comment style too with just a few lines of code.

http://www.lesscss.org/
http://www.dotlesscss.org/
