### PR TITLE
Issue5964

### DIFF
--- a/extension/content/firebug/cookies/cookieObserver.js
+++ b/extension/content/firebug/cookies/cookieObserver.js
@@ -136,11 +136,12 @@ var CookieObserver = Obj.extend(BaseObserver,
         //Steps 2,3 of RFC 6265 section 5.1.4
         if (activePath.length == 0 || activePath.charAt(0) != "/" || activePath.lastIndexOf("/") == 0)
             activePath = "/";
-        else {
+        else
+	{
             // Remove slash at the end of the active path according to step 4 of RFC 6265 section 5.1.4
-        	var lastChar = activePath.charAt(activePath.length - 1);
+            var lastChar = activePath.charAt(activePath.length - 1);
             if (lastChar == "/")
-        		activePath = activePath.substr(0, activePath.length - 1);
+       	        activePath = activePath.substr(0, activePath.length - 1);
         }
 
         // If the path filter is on, only cookies that match given path

--- a/extension/content/firebug/cookies/cookieObserver.js
+++ b/extension/content/firebug/cookies/cookieObserver.js
@@ -133,10 +133,15 @@ var CookieObserver = Obj.extend(BaseObserver,
         var activePath = queryStringPos != -1 ?
             activeUri.path.substr(0, queryStringPos) : activeUri.path;
 
-        // Remove slash at the end of the active path according to step 4 of RFC 6265 section 5.1.4
-        var lastChar = activePath.charAt(activePath.length - 1);
-        if (lastChar == "/")
-            activePath = activePath.substr(0, activePath.length - 1);
+        //Steps 2,3 of RFC 6265 section 5.1.4
+        if (activePath.length == 0 || activePath.charAt(0) != "/" || activePath.lastIndexOf("/") == 0)
+            activePath = "/";
+        else {
+            // Remove slash at the end of the active path according to step 4 of RFC 6265 section 5.1.4
+        	var lastChar = activePath.charAt(activePath.length - 1);
+            if (lastChar == "/")
+        		activePath = activePath.substr(0, activePath.length - 1);
+        }
 
         // If the path filter is on, only cookies that match given path
         // according to RFC 6265 section 5.1.4 will be displayed.


### PR DESCRIPTION
Steps 2,3 from RFC 6265 5.1.4 for calculating the path are missing from the current implementation in cookieObjerver.js and that explains issue 5964. If the path is empty or just a "/", we have to keep a "/" as the activePath.

In addition, as step 4 says: "Output the characters of the uri-path from the first character up to, but not including, the right-most %x2F ("/")."
If I understand it correctly, the "right-most" slash is not necessarily the last character of the path. So a path like /test/index.php will give /test as activePath.  If you agree with me I will update my patch and send a new pull request.
