### PR TITLE
some minor modifications for include() (issue6056)

### DIFF
--- a/extension/content/firebug/console/commandLineInclude.js
+++ b/extension/content/firebug/console/commandLineInclude.js
@@ -429,6 +429,8 @@ var CommandLineInclude =
 
         xhr.onload = function()
         {
+            if (xhr.status !== 200)
+                return errorFunction.apply(this, arguments);
             var codeToEval = xhr.responseText;
             Firebug.CommandLine.evaluateInWebPage(codeToEval, context);
             if (successFunction)
@@ -534,7 +536,7 @@ Firebug.registerCommand("include", {
 
 Firebug.registerRep(CommandLineIncludeRep);
 
-return CommandLineIncludeRep;
+return CommandLineInclude;
 
 // ********************************************************************************************* //
 }});

--- a/extension/content/firebug/console/commandLineInclude.js
+++ b/extension/content/firebug/console/commandLineInclude.js
@@ -362,13 +362,13 @@ var CommandLineInclude =
         // checking arguments:
         if ((newAlias !== undefined && typeof newAlias !== "string") || newAlias === "")
         {
-            this.log("wrongAliasArgument", [], [context, "error"]);
+            this.log("invalidAliasArgumentType", [], [context, "error"]);
             return returnValue;
         }
 
         if (url !== null && typeof url !== "string" || !url && !newAlias)
         {
-            this.log("wrongUrlArgument", [], [context, "error"]);
+            this.log("invalidUrlArgumentType", [], [context, "error"]);
             return returnValue;
         }
 

--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -775,7 +775,7 @@ commandline.include.aliasNotFound=Alias "%S" not found.
 # LOCALIZATION NOTE (commandline.include.loadFail): For the include() function. This message is displayed
 # in the Console panel when the remote script download failed
 # %S = the filename
-commandline.include.loadFail=the following script could not be loaded: %S.
+commandline.include.loadFail=The following script could not be loaded: %S
 
 # LOCALIZATION NOTE (commandline.include.invalidRequestProtocol): For the include() function. This message is displayed
 # in the Console panel when the user tries to download a script with another scheme than HTTP(S)
@@ -803,12 +803,12 @@ commandline.include.invalidAliasName=Alias names must not contain any "." or "/"
 commandline.include.tooLongAliasName=Alias names must not contain more than 30 characters; invalid alias name: "%S".
 
 # LOCALIZATION NOTE (commandline.include.wrongAliasArgument): For the include() function. This message is displayed
-# in the Console panel if the provided alias name is invalid
-commandline.include.wrongAliasArgument=Wrong alias name.
+# in the Console panel if the type of the alias name is invalid (a string is expected)
+commandline.include.invalidAliasArgumentType=Invalid second argument; expected alias name.
 
 # LOCALIZATION NOTE (commandline.include.wrongUrlArgument): For the include() function. This message is displayed
-# in the Console panel if the provided url argument is invalid
-commandline.include.wrongUrlArgument=Wrong url argument.
+# in the Console panel if the type of the url arguement is invalid (a string or null are expected)
+commandline.include.invalidUrlArgumentType=Invalid url argument.
 
 # LOCALIZATION NOTE (commandline.include.confirmDelete): For the include() function. This message is displayed
 # in a confirmation dialog when the user wants to delete an alias

--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -775,7 +775,7 @@ commandline.include.aliasNotFound=Alias "%S" not found.
 # LOCALIZATION NOTE (commandline.include.loadFail): For the include() function. This message is displayed
 # in the Console panel when the remote script download failed
 # %S = the filename
-commandline.include.loadFail=%S failed to load.
+commandline.include.loadFail=the following script could not be loaded: %S.
 
 # LOCALIZATION NOTE (commandline.include.invalidRequestProtocol): For the include() function. This message is displayed
 # in the Console panel when the user tries to download a script with another scheme than HTTP(S)
@@ -804,11 +804,11 @@ commandline.include.tooLongAliasName=Alias names must not contain more than 30 c
 
 # LOCALIZATION NOTE (commandline.include.wrongAliasArgument): For the include() function. This message is displayed
 # in the Console panel if the provided alias name is invalid
-commandline.include.wrongAliasArgument=Wrong alias argument; expected string.
+commandline.include.wrongAliasArgument=Wrong alias name.
 
 # LOCALIZATION NOTE (commandline.include.wrongUrlArgument): For the include() function. This message is displayed
 # in the Console panel if the provided url argument is invalid
-commandline.include.wrongUrlArgument=Wrong url argument; expected string or null.
+commandline.include.wrongUrlArgument=Wrong url argument.
 
 # LOCALIZATION NOTE (commandline.include.confirmDelete): For the include() function. This message is displayed
 # in a confirmation dialog when the user wants to delete an alias


### PR DESCRIPTION
Takes into account Honza's remarks: http://code.google.com/p/fbug/issues/detail?id=6056#c30

I took the freedom to add others changes:
- the return statement for commandLineInclude.js is now `CommandLineInclude`, that has more chance to be useful than `CommandLineRep`. Moreover, `CommandLineRep` can be shared if we store it in FirebugReps
- in firebug.properties, I adapted commandline.include.loadFail
- for commandline.include.wrongAliasArgument, the message is "Wrong alias **name**", that implicitly asks for a non-empty string. 

Don't hesitate to tell me if you are OK with them or not.

Thanks Honza

Florent
