### PR TITLE
Mutation observers for HTML, CSS panel + misc fixes

### DIFF
--- a/extension/content/firebug/chrome/tabContext.js
+++ b/extension/content/firebug/chrome/tabContext.js
@@ -510,7 +510,7 @@ Firebug.TabContext.prototype =
             }
 
             // Count how many messages have been logged during the throttle period
-            var logTime = new Date().getTime();
+            var logTime = Date.now();
             if (logTime - this.lastMessageTime < throttleTimeWindow)
                 ++this.throttleBuildup;
             else

--- a/extension/content/firebug/css/cssModule.js
+++ b/extension/content/firebug/css/cssModule.js
@@ -517,8 +517,9 @@ Firebug.CSSModule = Obj.extend(Firebug.Module, Firebug.EditorSelector,
         var cleaners = context.sheetCleaners;
         if (!cleaners.observers.has(win))
         {
-            // XXX: Maybe we should restrict ourselves to just
-            // document.head, non-recursively?
+            // XXXsimon: Maybe we should restrict ourselves to just
+            // document.head, non-recursively? It is probably possible to do
+            // this without mutation observers at all, too.
             var observer = new MutationObserver(cleaners.handler);
             cleaners.observers.set(win, observer);
             observer.observe(win.document, {

--- a/extension/content/firebug/css/cssModule.js
+++ b/extension/content/firebug/css/cssModule.js
@@ -520,6 +520,7 @@ Firebug.CSSModule = Obj.extend(Firebug.Module, Firebug.EditorSelector,
             // XXX: Maybe we should restrict ourselves to just
             // document.head, non-recursively?
             var observer = new MutationObserver(cleaners.handler);
+            cleaners.observers.set(win, observer);
             observer.observe(win.document, {
                 childList: true,
                 attributes: true,
@@ -535,6 +536,7 @@ Firebug.CSSModule = Obj.extend(Firebug.Module, Firebug.EditorSelector,
         if (cleaners && cleaners.observers.has(win))
         {
             var observer = cleaners.observers.get(win);
+            cleaners.observers.delete(win);
             observer.disconnect();
         }
     },

--- a/extension/content/firebug/css/cssModule.js
+++ b/extension/content/firebug/css/cssModule.js
@@ -273,13 +273,33 @@ Firebug.CSSModule = Obj.extend(Firebug.Module, Firebug.EditorSelector,
         return result;
     },
 
-    cleanupSheetHandler: function(event, context)
+    cleanupSheetHandler: function(context, records)
     {
-        var target = event.target;
-        var tagName = (target.tagName || "").toLowerCase();
+        var shouldHandle = false;
+        records.forEach(function(record)
+        {
+            if (record.type === "attributes")
+            {
+                if (record.target.tagName.toUpperCase() === "LINK")
+                    shouldHandle = true;
+            }
+            else
+            {
+                var nodes = record.addedNodes, len = nodes.length;
+                for (var i = 0; i < len; ++i)
+                {
+                    if (nodes[i].nodeType === 1 && // Node.ELEMENT_NODE
+                        nodes[i].tagName.toUpperCase() === "LINK")
+                    {
+                        shouldHandle = true;
+                        break;
+                    }
+                }
+            }
+        });
 
-        if (tagName == "link")
-            this.cleanupSheets(target.ownerDocument, context);
+        if (shouldHandle)
+            this.cleanupSheets(records[0].target.ownerDocument, context);
     },
 
     parseCSSValue: function(value, offset)
@@ -486,19 +506,36 @@ Firebug.CSSModule = Obj.extend(Firebug.Module, Firebug.EditorSelector,
 
     watchWindow: function(context, win)
     {
-        if (!context.cleanupSheetListener)
-            context.cleanupSheetListener = Obj.bind(this.cleanupSheetHandler, this, context);
+        if (!context.sheetCleaners)
+        {
+            context.sheetCleaners = {
+                handler: this.cleanupSheetHandler.bind(this, context),
+                observers: new WeakMap()
+            };
+        }
 
-        context.addEventListener(win, "DOMAttrModified", context.cleanupSheetListener, false);
-        context.addEventListener(win, "DOMNodeInserted", context.cleanupSheetListener, false);
+        var cleaners = context.sheetCleaners;
+        if (!cleaners.observers.has(win))
+        {
+            // XXX: Maybe we should restrict ourselves to just
+            // document.head, non-recursively?
+            var observer = new MutationObserver(cleaners.handler);
+            observer.observe(win.document, {
+                childList: true,
+                attributes: true,
+                attributeFilter: ["disabled", "href", "media", "type", "rel"],
+                subtree: true
+            });
+        }
     },
 
     unwatchWindow: function(context, win)
     {
-        if (context.cleanupSheetListener)
+        var cleaners = context.sheetCleaners;
+        if (cleaners && cleaners.observers.has(win))
         {
-            context.removeEventListener(win, "DOMAttrModified", context.cleanupSheetListener, false);
-            context.removeEventListener(win, "DOMNodeInserted", context.cleanupSheetListener, false);
+            var observer = cleaners.observers.get(win);
+            observer.disconnect();
         }
     },
 

--- a/extension/content/firebug/css/stylePanel.js
+++ b/extension/content/firebug/css/stylePanel.js
@@ -305,7 +305,10 @@ CSSStylePanel.prototype = Obj.extend(CSSStyleSheetPanel.prototype,
             if (!dummyStyle)
             {
                 if (FBTrace.DBG_ERRORS)
-                    FBTrace.sysout("css.markOverridenProps; ERROR dummyStyle is NULL");
+                {
+                    FBTrace.sysout("css.markOverridenProps; ERROR dummyStyle is NULL for clone " +
+                        "of " + element, dummyElement);
+                }
                 return;
             }
 

--- a/extension/content/firebug/html/htmlLib.js
+++ b/extension/content/firebug/html/htmlLib.js
@@ -750,12 +750,22 @@ var HTMLLib =
      */
     findNextSibling: function(node)
     {
+        return this.findNextNodeFrom(node.nextSibling);
+    },
+
+    /**
+     * Like findNextSibling, except it also allows returning the node itself.
+     */
+    findNextNodeFrom: function(node)
+    {
         if (Firebug.showTextNodesWithWhitespace)
-            return node.nextSibling;
+        {
+            return node;
+        }
         else
         {
             // only return a non-whitespace node
-            for (var child = node.nextSibling; child; child = child.nextSibling)
+            for (var child = node; child; child = child.nextSibling)
             {
                 if (!HTMLLib.isWhitespaceText(child))
                     return child;

--- a/extension/content/firebug/html/htmlPanel.js
+++ b/extension/content/firebug/html/htmlPanel.js
@@ -120,19 +120,20 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
     stopEditing: function()
     {
         Firebug.Editor.stopEditing();
-
-        // After mutation listeners have made the element appear in the panel,
-        // re-select it (and also update the disable state of the "Edit" button).
-        this.context.delay(function()
-        {
-            this.select(this.selection, true);
-        }.bind(this));
     },
 
     isEditing: function()
     {
         var editButton = Firebug.chrome.$("fbToggleHTMLEditing");
         return (this.editing && editButton.getAttribute("checked") === "true");
+    },
+
+    // Update the Edit button to reflect editability of the selection
+    setEditEnableState: function(ignoreEditing)
+    {
+        var editButton = Firebug.chrome.$("fbToggleHTMLEditing");
+        editButton.disabled = (this.selection && (!this.isEditing() || ignoreEditing) &&
+            Css.nonEditableTags.hasOwnProperty(this.selection.localName));
     },
 
     resetSearch: function()
@@ -156,11 +157,7 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
             this.selection = object;
             this.updateSelection(object);
 
-            // Update the Edit button to reflect editability of the selection.
-            // (Except during editing, when it should always be possible to click it.)
-            var editButton = Firebug.chrome.$("fbToggleHTMLEditing");
-            editButton.disabled = (this.selection && !this.isEditing() &&
-                Css.nonEditableTags.hasOwnProperty(this.selection.localName));
+            this.setEditEnableState();
 
             // Distribute selection change further to listeners.
             Events.dispatch(Firebug.uiListeners, "onObjectSelected", [object, this]);
@@ -2645,6 +2642,7 @@ HTMLEditor.prototype = domplate(Firebug.BaseEditor,
     endEditing: function()
     {
         //this.panel.markChange();
+        this.panel.setEditEnableState(true);
         return true;
     },
 

--- a/extension/content/firebug/html/htmlPanel.js
+++ b/extension/content/firebug/html/htmlPanel.js
@@ -767,13 +767,14 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
             if (!parentNodeBox)
                 return;
 
+            // Ignore whitespace nodes.
             if (!Firebug.showTextNodesWithWhitespace && this.isWhitespaceText(target))
                 return;
 
-            // target is only whitespace
-
             var newParentTag = getNodeTag(parent);
             var oldParentTag = getNodeBoxTag(parentNodeBox);
+
+            var objectBox = null;
 
             if (newParentTag == oldParentTag)
             {
@@ -810,7 +811,7 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
                            nextSibling = this.findNextSibling(nextSibling);
                         }
 
-                        var objectBox = nextSibling ?
+                        objectBox = nextSibling ?
                             this.ioBox.insertChildBoxBefore(parentNodeBox, target, nextSibling) :
                             this.ioBox.appendChildBox(parentNodeBox, target);
 
@@ -836,7 +837,7 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
 
                     if (!removal && (Firebug.scrollToMutations || Firebug.expandMutations))
                     {
-                        var objectBox = this.ioBox.createObjectBox(target);
+                        objectBox = this.ioBox.createObjectBox(target);
                         this.highlightMutation(objectBox, objectBox, "mutated");
                     }
                 }
@@ -857,10 +858,13 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
 
                 if (!removal && (Firebug.scrollToMutations || Firebug.expandMutations))
                 {
-                    var objectBox = this.ioBox.createObjectBox(target);
+                    objectBox = this.ioBox.createObjectBox(target);
                     this.highlightMutation(objectBox, objectBox, "mutated");
                 }
             }
+
+            if (objectBox && this.selection === target)
+                this.ioBox.selectObjectBox(objectBox);
         }
         catch (exc)
         {

--- a/extension/content/firebug/html/htmlPanel.js
+++ b/extension/content/firebug/html/htmlPanel.js
@@ -472,7 +472,7 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
         if (!context.registeredHTMLMutationObservers)
             return;
 
-        function addObserver(win)
+        function removeObserver(win)
         {
             var doc = win.document;
             var observer = context.registeredHTMLMutationObservers.get(doc);
@@ -484,9 +484,9 @@ Firebug.HTMLPanel.prototype = Obj.extend(WalkingPanel,
         }
 
         if (win)
-            addObserver(win);
+            removeObserver(win);
         else
-            Win.iterateWindows(context.window, addObserver);
+            Win.iterateWindows(context.window, removeObserver);
     },
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/extension/content/firebug/html/inspector.js
+++ b/extension/content/firebug/html/inspector.js
@@ -74,10 +74,12 @@ Firebug.Inspector = Obj.extend(Firebug.Module,
 
         if (!elementArr || !Arr.isArrayLike(elementArr))
         {
+            // Not everything that comes through here is wrapped - fix that.
+            elementArr = Wrapper.wrapObject(elementArr);
+
             // highlight a single element
             if (!elementArr || !Dom.isElement(elementArr) ||
-                (Wrapper.getContentView(elementArr) &&
-                    !Xml.isVisible(Wrapper.getContentView(elementArr))))
+                (typeof elementArr === "object" && !Xml.isVisible(elementArr)))
             {
                 if (elementArr && Dom.isRange(elementArr))
                     elementArr = elementArr;
@@ -146,7 +148,8 @@ Firebug.Inspector = Obj.extend(Firebug.Module,
             {
                 for (i=0, elementLen=elementArr.length; i<elementLen; i++)
                 {
-                    elt = elementArr[i];
+                    // Like above, wrap things.
+                    elt = Wrapper.wrapObject(elementArr[i]);
 
                     if (elt && elt instanceof HTMLElement)
                     {

--- a/extension/content/firebug/lib/wrapper.js
+++ b/extension/content/firebug/lib/wrapper.js
@@ -34,6 +34,11 @@ Wrapper.wrapObject = function(object)
     return XPCNativeWrapper(object);
 };
 
+Wrapper.isDeadWrapper = function(wrapper)
+{
+    return Components.utils.isDeadWrapper(wrapper);
+};
+
 Wrapper.unwrapIValue = function(object, viewChrome)
 {
     var unwrapped = object.getWrappedValue();

--- a/extension/content/firebug/lib/wrapper.js
+++ b/extension/content/firebug/lib/wrapper.js
@@ -12,7 +12,7 @@ var Wrapper = {};
 
 Wrapper.getContentView = function(object)
 {
-    if (typeof object !== "object" && typeof object !== "function")
+    if (isPrimitive(object))
         return object;
 
     return object.wrappedJSObject;
@@ -20,14 +20,10 @@ Wrapper.getContentView = function(object)
 
 Wrapper.unwrapObject = function(object)
 {
-    // TODO: We might be able to make this check more authoritative with QueryInterface.
-    if (typeof(object) === 'undefined' || object == null)
+    if (isPrimitive(object))
         return object;
 
-    if (object.wrappedJSObject)
-        return object.wrappedJSObject;
-
-    return object;
+    return XPCNativeWrapper.unwrap(object);
 };
 
 Wrapper.unwrapIValue = function(object, viewChrome)
@@ -113,6 +109,11 @@ Wrapper.shouldIgnore = function(name)
 {
     return (Wrapper.ignoreVars[name] === 1);
 };
+
+function isPrimitive(obj)
+{
+    return !(obj && (typeof obj === "object" || typeof obj === "function"));
+}
 
 // ********************************************************************************************* //
 

--- a/extension/content/firebug/lib/wrapper.js
+++ b/extension/content/firebug/lib/wrapper.js
@@ -26,6 +26,14 @@ Wrapper.unwrapObject = function(object)
     return XPCNativeWrapper.unwrap(object);
 };
 
+Wrapper.wrapObject = function(object)
+{
+    if (isPrimitive(object))
+        return object;
+
+    return XPCNativeWrapper(object);
+};
+
 Wrapper.unwrapIValue = function(object, viewChrome)
 {
     var unwrapped = object.getWrappedValue();

--- a/tests/content/html/5448/issue5448.html
+++ b/tests/content/html/5448/issue5448.html
@@ -22,7 +22,7 @@
             <li>Execute on the command line:
             <pre>$0.appendChild(document.createTextNode(' tnode')); $0.normalize();</pre>
             </li>
-            <li>Switch back to the HTML panel. <code>&lt;section id="content&gt;</code>
+            <li>Switch back to the HTML panel. <code>&lt;section id="content"&gt;</code>
             element must contain:<br/><br/>
             <pre>a &amp;aring;&amp;auml;&amp;ouml; b</pre>
             </li>

--- a/tests/content/html/5448/issue5448.js
+++ b/tests/content/html/5448/issue5448.js
@@ -23,10 +23,10 @@ function runTest()
                 FBTest.selectPanel("html");
 
                 // Wait till the executed expression causes HTML panel update.
-                FBTest.waitForHtmlMutation(null, "span", function(node)
+                FBTest.waitForHtmlMutation(null, "div", function(node)
                 {
                     // Verify HTML panel content after mutation.
-                    var expected = /a &aring;&auml;&ouml; b/;
+                    var expected = /section.*a &aring;&auml;&ouml; b.*section/;
                     FBTest.compare(expected, node.textContent, "The text content must match");
 
                     FBTest.testDone("issue5448.DONE");

--- a/tests/content/html/breakpoints/breakOnElement.html
+++ b/tests/content/html/breakpoints/breakOnElement.html
@@ -22,6 +22,7 @@ HTML panel. This features allows to debug mutation events (<i>DOMAttrModified</i
     <ul>
         <li>Break on Attribute Change</li>
         <li>Break on Child Addition or Removal</li>
+        <li>Break on Child Addition or Removal</li>
         <li>Break on Element Removal</li>
     </ul>
 </li>
@@ -32,7 +33,8 @@ always breaks at the proper location.</li>
 <h3 id="content" style="color:green">Test Element</h3>
 
 <button id="breakOnAttrModified" onclick="breakOnAttrModified()">Break on Attribute Modified</button>
-<button id="breakOnNodeInserted" onclick="breakOnNodeInserted()">Break on Node Inserted</button>
+<button id="breakOnChildInserted" onclick="breakOnChildInserted()">Break on Child Inserted</button>
+<button id="breakOnChildRemoved" onclick="breakOnChildRemoved()">Break on Child Removed</button>
 <button id="breakOnNodeRemoved" onclick="breakOnNodeRemoved()">Break on Node Removed</button>
 
 <script type="text/javascript">
@@ -40,20 +42,22 @@ var content = document.getElementById("content");
 function breakOnAttrModified()
 {
     var now = (new Date()).getTime();
-    content.setAttribute("test", now); // Line 42 do not move
+    content.setAttribute("test", now); // Line 45 do not move
 }
 
-function breakOnNodeInserted()
+function breakOnChildInserted()
 {
-    content.appendChild(document.createElement("div"));  // line 47 do not move
+    content.appendChild(document.createElement("div"));  // line 50 do not move
+}
+
+function breakOnChildRemoved()
+{
+    content.removeChild(content.firstChild);  // line 55 do not move
 }
 
 function breakOnNodeRemoved()
 {
-    if (content.firstChild)
-        content.removeChild(content.firstChild);  // line 53 do not move
-    else
-        alert("You have to append a node first. Use 'Break on Node Inserted'.");
+    content.parentNode.removeChild(content);  // line 60 do not move
 }
 
 </script>

--- a/tests/content/html/breakpoints/breakOnElement.js
+++ b/tests/content/html/breakpoints/breakOnElement.js
@@ -20,13 +20,16 @@ function runTest()
         // A suite of asynchronous tests.
         var testSuite = [];
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONATTRCHANGE, "breakOnAttrModified", 43, callback);
+            breakOnMutation(win, BP_BREAKONATTRCHANGE, "breakOnAttrModified", 45, callback);
         });
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnNodeInserted", 48, callback);
+            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnChildInserted", 50, callback);
         });
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONREMOVE, "breakOnNodeRemoved", 54, callback);
+            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnChildRemoved", 55, callback);
+        });
+        testSuite.push(function(callback) {
+            breakOnMutation(win, BP_BREAKONREMOVE, "breakOnNodeRemoved", 60, callback);
         });
 
         // Reload window to activate debugger and run all tests.
@@ -55,6 +58,11 @@ function breakOnMutation(win, type, buttonId, lineNo, callback)
         FBTest.sysout("html.breakpoints; " + buttonId);
         FBTest.clickContinueButton(chrome);
         FBTest.progress("The continue button is pushed");
+
+        // Remove breakpoint.
+        FW.Firebug.HTMLModule.MutationBreakpoints.onModifyBreakpoint(context,
+            content, type);
+
         callback();
     });
 

--- a/tests/content/html/breakpoints/breakOnElementCB.js
+++ b/tests/content/html/breakpoints/breakOnElementCB.js
@@ -25,13 +25,16 @@ function runTest()
         // A suite of asynchronous tests.
         var testSuite = [];
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONATTRCHANGE, "breakOnAttrModified", 43, callback);
+            breakOnMutation(win, BP_BREAKONATTRCHANGE, "breakOnAttrModified", 45, callback);
         });
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnNodeInserted", 48, callback);
+            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnChildInserted", 50, callback);
         });
         testSuite.push(function(callback) {
-            breakOnMutation(win, BP_BREAKONREMOVE, "breakOnNodeRemoved", 54, callback);
+            breakOnMutation(win, BP_BREAKONCHILDCHANGE, "breakOnChildRemoved", 55, callback);
+        });
+        testSuite.push(function(callback) {
+            breakOnMutation(win, BP_BREAKONREMOVE, "breakOnNodeRemoved", 60, callback);
         });
 
         // Reload window to activate debugger and run all tests.
@@ -60,6 +63,11 @@ function breakOnMutation(win, type, buttonId, lineNo, callback)
         FBTest.sysout("html.breakpoints.CB; " + buttonId);
         FBTest.clickContinueButton(chrome);
         FBTest.progress("The continue button is pushed");
+
+        // Remove breakpoint.
+        FW.Firebug.HTMLModule.MutationBreakpoints.onModifyBreakpoint(context,
+            content, type);
+
         callback();
     });
 


### PR DESCRIPTION
Makes the HTML panel use mutation observers, except for "break on *".

Also includes use of mutation observers in the CSS panel ([see issue 6176](http://code.google.com/p/fbug/issues/detail?id=6176) - might need some discussion) and some random fixes to lib/wrapper because I'm too lazy to separate things.

html/ FBTests pass locally, at least.
