### PR TITLE
Fixed typo in japanese

### DIFF
--- a/extension/locale/ja-JP/firebug.properties
+++ b/extension/locale/ja-JP/firebug.properties
@@ -1447,7 +1447,7 @@ console.cmd.help.help=利用可能なすべてのコマンドのヘルプを表�
 console.cmd.helpUrlNotAvailable=このコマンドのヘルプページはありません。
 # LOCALIZATION NOTE (css.selector.noSelection): A help description used in empty
 # Selection side panel.
-css.selector.noSelection=カスタクセレクタを打ち込むか、CSS ルールを右クリックして<b>マッチする要素を取得</b>を選びます。
+css.selector.noSelection=カスタムセレクタを打ち込むか、CSS ルールを右クリックして<b>マッチする要素を取得</b>を選びます。
 css.selector.noSelectionResults=マッチする要素なし
 css.selector.selectorError=選択に失敗:
 # LOCALIZATION NOTE (css.selector.Selection): Title for Selector side panel displayed


### PR DESCRIPTION
Hello.

I found a typo in japanese at css.selector.noSelection and fixed it.

Sincerely,
azanael
