### PR TITLE
Added Fuzzy Search Capabilities to File Filter

### DIFF
--- a/extension/content/firebug/firefox/bindings.xml
+++ b/extension/content/firebug/firefox/bindings.xml
@@ -1350,7 +1350,7 @@
                     if (child.localName == "menuitem")
                     {
                         var label = child.getAttribute("tooltiptext").toLowerCase();
-                        child._searchMatch = this.fuzzySearch(label, substring);
+                        child._searchMatch = this.fuzzySearchByPath(label, substring);
                         if (child._searchMatch)
                         {
                             this.firstMatch = child;
@@ -1437,19 +1437,51 @@
             </body>
         </method>
 
+        <method name="fuzzySearchByPath">
+            <parameter name="label"/>
+            <parameter name="token"/>
+            <body><![CDATA[
+                // split the search token and label by path segments
+                var paths = label.split('/'), tokens = token.split('/');
+                // remove query string variables from the filename
+                paths[paths.length - 1] = paths[paths.length - 1].split('?')[0];
+                if (tokens.length === 1) {  // only match by filename
+                    return this.fuzzySearch(paths[paths.length - 1], token);
+                }
+                else {  // search for consecutive file path segment matches
+                    var pathIdx = 0
+                    for (var i = 0; i < tokens.length; i++) {
+                        var match = false;
+                        for (pathIdx; pathIdx < paths.length; ++pathIdx) {
+                            if (this.fuzzySearch(paths[pathIdx], tokens[i])) {
+                                match = true; ++pathIdx; break;
+                            }
+                        }
+                        if (!match) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            ]]>
+            </body>
+        </method>
+
         <method name="fuzzySearch">
             <parameter name="label"/>
             <parameter name="token"/>
             <body><![CDATA[
-                // create a fuzzy search regular expression based on the token,
-                // e.g. "asd" => [^a]*a[^s]*s[^d]*d
-                var letters = token.split(''), tokens = [];
-                for (var i = 0; i < letters.length; i++) {
-                    var letter = letters[i];
-                    tokens.push('[^' + letter + ']*' + letter);
+                if (!!label && !!token) {
+                    // create a fuzzy search regular expression based on the token,
+                    // e.g. "asd" => [^a]*a[^s]*s[^d]*d
+                    var letters = token.split(''), tokens = [];
+                    for (var i = 0; i < letters.length; i++) {
+                        var letter = letters[i];
+                        tokens.push('[^' + letter + ']*' + letter);
+                    }
+                    var patt = new RegExp(tokens.join(''));
+                    return patt.test(label);
                 }
-                var patt = new RegExp(tokens.join(''));
-                return patt.test(label);
             ]]>
             </body>
         </method>

--- a/extension/content/firebug/firefox/bindings.xml
+++ b/extension/content/firebug/firefox/bindings.xml
@@ -1343,14 +1343,16 @@
             <parameter name="substring"/>
             <body><![CDATA[
                 this.firstMatch = null;
-                var groupMatchCount = 0;
                 substring = substring.toLowerCase();
+                var groupMatchCount = 0;
+                var SearchLib = Firebug.require("firebug/lib/search");
                 for (var child = this.popup.lastChild; child; child = child.previousSibling)
                 {
                     if (child.localName == "menuitem")
                     {
                         var label = child.getAttribute("tooltiptext").toLowerCase();
-                        child._searchMatch = this.fuzzySearchByPath(label, substring);
+                        var FuzzySearch = new SearchLib.FuzzySearch(label, substring);
+                        child._searchMatch = FuzzySearch.findByPath();
                         if (child._searchMatch)
                         {
                             this.firstMatch = child;
@@ -1433,55 +1435,6 @@
                     FBL.$STR("script.Type any key to filter list");
 
                 this.setAttribute("value", filterString);
-            ]]>
-            </body>
-        </method>
-
-        <method name="fuzzySearchByPath">
-            <parameter name="label"/>
-            <parameter name="token"/>
-            <body><![CDATA[
-                // split the search token and label by path segments
-                var paths = label.split('/'), tokens = token.split('/');
-                // remove query string variables from the filename
-                paths[paths.length - 1] = paths[paths.length - 1].split('?')[0];
-                if (tokens.length === 1) {  // only match by filename
-                    return this.fuzzySearch(paths[paths.length - 1], token);
-                }
-                else {  // search for consecutive file path segment matches
-                    var pathIdx = 0
-                    for (var i = 0; i < tokens.length; i++) {
-                        var match = false;
-                        for (pathIdx; pathIdx < paths.length; ++pathIdx) {
-                            if (this.fuzzySearch(paths[pathIdx], tokens[i])) {
-                                match = true; ++pathIdx; break;
-                            }
-                        }
-                        if (!match) {
-                            return false;
-                        }
-                    }
-                    return true;
-                }
-            ]]>
-            </body>
-        </method>
-
-        <method name="fuzzySearch">
-            <parameter name="label"/>
-            <parameter name="token"/>
-            <body><![CDATA[
-                if (!!label && !!token) {
-                    // create a fuzzy search regular expression based on the token,
-                    // e.g. "asd" => [^a]*a[^s]*s[^d]*d
-                    var letters = token.split(''), tokens = [];
-                    for (var i = 0; i < letters.length; i++) {
-                        var letter = letters[i];
-                        tokens.push('[^' + letter + ']*' + letter);
-                    }
-                    var patt = new RegExp(tokens.join(''));
-                    return patt.test(label);
-                }
             ]]>
             </body>
         </method>

--- a/extension/content/firebug/firefox/bindings.xml
+++ b/extension/content/firebug/firefox/bindings.xml
@@ -1350,7 +1350,7 @@
                     if (child.localName == "menuitem")
                     {
                         var label = child.getAttribute("tooltiptext").toLowerCase();
-                        child._searchMatch = label.indexOf(substring) != -1;
+                        child._searchMatch = this.fuzzySearch(label, substring);
                         if (child._searchMatch)
                         {
                             this.firstMatch = child;
@@ -1433,6 +1433,23 @@
                     FBL.$STR("script.Type any key to filter list");
 
                 this.setAttribute("value", filterString);
+            ]]>
+            </body>
+        </method>
+
+        <method name="fuzzySearch">
+            <parameter name="label"/>
+            <parameter name="token"/>
+            <body><![CDATA[
+                // create a fuzzy search regular expression based on the token,
+                // e.g. "asd" => [^a]*a[^s]*s[^d]*d
+                var letters = token.split(''), tokens = [];
+                for (var i = 0; i < letters.length; i++) {
+                    var letter = letters[i];
+                    tokens.push('[^' + letter + ']*' + letter);
+                }
+                var patt = new RegExp(tokens.join(''));
+                return patt.test(label);
             ]]>
             </body>
         </method>

--- a/extension/content/firebug/firefox/bindings.xml
+++ b/extension/content/firebug/firefox/bindings.xml
@@ -1351,8 +1351,7 @@
                     if (child.localName == "menuitem")
                     {
                         var label = child.getAttribute("tooltiptext").toLowerCase();
-                        var FuzzySearch = new SearchLib.FuzzySearch(label, substring);
-                        child._searchMatch = FuzzySearch.findByPath();
+                        child._searchMatch = SearchLib.FuzzySearch.findByPath(label, substring);
                         if (child._searchMatch)
                         {
                             this.firstMatch = child;

--- a/extension/content/firebug/lib/search.js
+++ b/extension/content/firebug/lib/search.js
@@ -371,8 +371,10 @@ Search.FuzzySearch.findByPath = function(text, token)
     // Split the search token and text by path segments.
     var paths = text.split("/");
     var tokens = token.split("/");
-    // Remove query string variables from the filename.
-    paths[paths.length - 1] = paths[paths.length - 1].split("?")[0];
+    // If a question mark doesn't appear in the search text, 
+    // remove query string variables from the filename.
+    if (token.indexOf("?") === -1)
+        paths[paths.length - 1] = paths[paths.length - 1].split("?")[0];
     if (tokens.length === 1)
     {
         // Only match by filename.

--- a/extension/content/firebug/lib/search.js
+++ b/extension/content/firebug/lib/search.js
@@ -355,17 +355,12 @@ Search.FuzzySearch = function(text, token)
 {
     this.text = text;
     this.token = token;
-    var specialChars = [".", "\\", "?", "[", "^", "]", "$", "(", ")",
-                        "{", "}", "=", "!", "<", ">", "|", ":", "-"];
+    var specialChars = /[.\\\?\[\]\^\$\(\)\{\}\=\!<\>\|\:\-]/;
 
     function escape(character)
     {
-        for (var i = 0; i < specialChars.length; i++)
-        {
-            if (specialChars[i] === character)
-            {
-                return "\\" + character;
-            }
+        if (specialChars.test(character)) {
+            return "\\" + character;
         }
         return character;
     }
@@ -382,6 +377,7 @@ Search.FuzzySearch = function(text, token)
             tokens.push("[^" + letter + "]*" + letter);
         }
         var patt = new RegExp(tokens.join(""));
+        FBTrace.sysout(patt);
         return patt.test(text);
     };
 

--- a/extension/content/firebug/lib/search.js
+++ b/extension/content/firebug/lib/search.js
@@ -368,6 +368,10 @@ Search.FuzzySearch.find = function(text, token)
  */
 Search.FuzzySearch.findByPath = function(text, token)
 {
+    // If there's an exact match, return true.
+    if (text.indexOf(token) !== -1)
+        return true;
+
     // Split the search token and text by path segments.
     var paths = text.split("/");
     var tokens = token.split("/");

--- a/extension/content/firebug/lib/search.js
+++ b/extension/content/firebug/lib/search.js
@@ -359,7 +359,8 @@ Search.FuzzySearch = function(text, token)
 
     function escape(character)
     {
-        if (specialChars.test(character)) {
+        if (specialChars.test(character))
+        {
             return "\\" + character;
         }
         return character;
@@ -367,7 +368,7 @@ Search.FuzzySearch = function(text, token)
 
     this.find = function(text, token)
     {
-        // create a fuzzy search regular expression based on the token,
+        // Create a fuzzy search regular expression based on the token,
         // e.g. "asd" => "[^a]*a[^s]*s[^d]*d".
         var letters = token.split("");
         var tokens = [];
@@ -383,19 +384,19 @@ Search.FuzzySearch = function(text, token)
 
     this.findByPath = function()
     {
-        // split the search token and text by path segments
+        // Split the search token and text by path segments.
         var paths = this.text.split("/");
         var tokens = this.token.split("/");
-        // remove query string variables from the filename
+        // Remove query string variables from the filename.
         paths[paths.length - 1] = paths[paths.length - 1].split("?")[0];
         if (tokens.length === 1)
         {
-            // only match by filename
+            // Only match by filename.
             return this.find(paths[paths.length - 1], this.token);
         }
         else
         {
-            // search for consecutive file path segment matches
+            // Search for consecutive file path segment matches.
             var pathIdx = 0;
             for (var i = 0; i < tokens.length; i++)
             {

--- a/extension/content/firebug/lib/search.js
+++ b/extension/content/firebug/lib/search.js
@@ -380,7 +380,7 @@ Search.FuzzySearch.findByPath = function(text, token)
     }
     else
     {
-        // Search for consecutive file path segment matches.
+        // Search for subsequent file path segment matches.
         var pathIdx = 0;
         for (var i = 0; i < tokens.length; i++)
         {


### PR DESCRIPTION
Websites in development mode often use many static assets, including javascript and CSS files, which become difficult to scroll through quickly.  Firebug's existing file filter allows you to find files by searching for an exact file path match, but often this is too slow if this needs to be done many times per day.

Editors like TextMate and Sublime Text 2 utilize [fuzzy searching](http://en.wikipedia.org/wiki/Approximate_string_matching) to make finding files a treat, and this is what I've added to Firebug's file filter.  With only about _40 lines of code_, users can now find files that include the correct sequence of characters but possibly with other characters between:

![1](https://f.cloud.github.com/assets/795979/595930/73af1a3a-cb42-11e2-85ae-efea27ec8acb.png)

In the example above, notice that I no longer need to type the full name of the file to have the correct file display as a search result.  And further, both uploadifive and uploadify scripts appear next to each other, making it easy to see all related files **without needing to remember** the exact name of the file beforehand.

Even better, we can also now **filter by the entire file path** by including '/' forward slash characters in our search token:

![2](https://f.cloud.github.com/assets/795979/595931/927f4098-cb42-11e2-9f16-a49ae33699fa.png)

Using three simple characters 'fiv' above, I've limited my query to the uploadifive folder.

I'm really hoping this will be added to the trunk, since this will save developers little bits of time _many many_ times over the course of many hours of daily debugging time.
