### PR TITLE
Fix: Missing message "firebug.All" in console.

### DIFF
--- a/extension/content/firebug/firebugOverlay.xul
+++ b/extension/content/firebug/firebugOverlay.xul
@@ -181,7 +181,7 @@
                                             <toolbarbutton
                                                 id="fbConsoleFilter-all"
                                                 type="checkbox"
-                                                label="firebug.All"
+                                                label="firebug.console.All"
                                                 class="toolbar-text-button fbConsoleFilter fbInternational"
                                                 tooltiptext="firebug.console.Show All Log Entries"
                                                 oncommand="Firebug.Console.onToggleFilter(event, Firebug.currentContext, 'all')"/>

--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -1136,6 +1136,7 @@ search.net.Response_Bodies=Response Bodies
 search.net.tip.Response_Bodies=Search also in response bodies
 firebug.console.Persist=Persist
 firebug.console.Do_Not_Clear_On_Reload2=Do not clear the panel on page reload
+firebug.console.All=All
 firebug.console.Show_All_Log_Entries=Show all log entries
 firebug.console.Errors=Errors
 firebug.console.Filter_by_Errors=Filter by errors


### PR DESCRIPTION
While I was working for translation, I found that a message entry is missing in newest version of Firebug.
