### PR TITLE
6895: Only select the string without quotes when editing a string property

### DIFF
--- a/extension/content/firebug/dom/domBasePanel.js
+++ b/extension/content/firebug/dom/domBasePanel.js
@@ -844,7 +844,11 @@ Firebug.DOMBasePanel.prototype = Obj.extend(Firebug.Panel,
                     editValue = "this." + getRowName(row); // XXX "this." doesn't actually work
             }
 
-            Firebug.Editor.startEditing(row, editValue);
+            var selectionData = null;
+            if (type === "string")
+                selectionData = {start: 1, end: editValue.length-1};
+
+            Firebug.Editor.startEditing(row, editValue, null, selectionData);
         }
     },
 

--- a/tests/content/dom/6895/issue6895.html
+++ b/tests/content/dom/6895/issue6895.html
@@ -20,8 +20,12 @@
         <ol>
             <li>Open firebug</li>
             <li>Switch to the DOM panel</li>
-            <li>....</li>
+            <li>Double click the member value cell of <code>testString</code></li>
         </ol>
+        <h3>Expected result</h3>
+        <ul>
+            <li>Only the string within the double quotes should be selected</li>
+        </ul>
     </section>
     <footer>
         Thomas Andersen, &lt;thomas@mr-andersen.no&gt;

--- a/tests/content/dom/6895/issue6895.html
+++ b/tests/content/dom/6895/issue6895.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Issue 6895: Only select the string without quotes when editing a string property</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link href="../../_common/testcase.css" type="text/css" rel="stylesheet"/>
+
+    <script>
+        var testString = "Test text";
+    </script>
+</head>
+<body>
+<header>
+    <h1><a href="http://code.google.com/p/fbug/issues/detail?id=6895">Issue 6895</a>:
+        Only select the string without quotes when editing a string property</h1>
+</header>
+<div>
+    <section id="description">
+        <h3>Steps to reproduce</h3>
+        <ol>
+            <li>Open firebug</li>
+            <li>Switch to the DOM panel</li>
+            <li>....</li>
+        </ol>
+    </section>
+    <footer>
+        Thomas Andersen, &lt;thomas@mr-andersen.no&gt;
+    </footer>
+</div>
+</body>
+</html>

--- a/tests/content/dom/6895/issue6895.js
+++ b/tests/content/dom/6895/issue6895.js
@@ -1,0 +1,32 @@
+function runTest()
+{
+    FBTest.sysout("issue6895.START");
+
+    FBTest.openNewTab(basePath + "dom/6895/issue6895.html", function(win)
+    {
+        FBTest.openFirebug();
+
+        FBTest.waitForDOMProperty("testString", function(row)
+        {
+            var memberValueElement = row.getElementsByClassName("memberValueCell")[0];
+
+            FBTest.dblclick(memberValueElement);
+
+            var panel = FBTest.getPanelDocument();
+            var editorInput = panel.getElementsByClassName("completionInput")[0];
+
+            FBTest.compare("\"Test text\"", editorInput.value,
+                "The editor's value should be encapsulated in double quotes");
+
+            var selectedText = editorInput.value.substring(editorInput.selectionStart, editorInput.selectionEnd);
+            FBTest.compare("Test text", selectedText,
+                "Only the text inside the double quotes should be selected");
+
+            FBTest.click(editorInput.parentNode);
+
+            FBTest.testDone("issue6895.DONE");
+        });
+
+        FBTest.selectPanel("dom");
+    });
+}

--- a/tests/content/firebug.html
+++ b/tests/content/firebug.html
@@ -342,6 +342,7 @@ var testList = [
     {group: "dom",                uri: "dom/6283/issue6283.js",                   desc: "Console and DOM panel fail on interpreting @page", testPage: "dom/6283/issue6283.html" },
     {group: "dom",                uri: "dom/sidePanel/sidePanel.js",              desc: "Existence of the side panel", testPage: "dom/sidePanel/sidePanel.html" },
     {group: "dom", disabled: "See issue 6842", uri: "dom/6481/issue6481.js",                   desc: "Closures no longer shown in DOM panel", testPage: "dom/6481/issue6481.html" },
+    {group: "dom",                uri: "dom/6895/issue6895.js",                   desc: "Only select the string without quotes when editing a string property", testPage: "dom/6895/issue6895.html" },
     {group: "net",                uri: "net/activation/activation.js",            desc: "Verify Net panel content after activation on more tabs (Firebug opened within Firefox)." },
     {group: "net",                uri: "net/breakpoints/breakOnXHR.js",           desc: "XHR Conditional Breakpoints", testPage: "net/breakpoints/breakOnXHR.html" },
     {group: "net",                uri: "net/breakpoints/breakOnXHRCB.js",         desc: "XHR Conditional Breakpoints (Chromebug active)", testPage: "net/breakpoints/breakOnXHR.html" },


### PR DESCRIPTION
- pass a selectionRange for string the editor's startEditing method
- FBTest
