### PR TITLE
prevents exception when logFormatted is called by javascript code injected from content-scripts

### DIFF
--- a/extension/content/firebug/console/consoleExposed.js
+++ b/extension/content/firebug/console/consoleExposed.js
@@ -399,7 +399,7 @@ function createFirebugConsole(context, win)
         var sourceLink = StackFrame.getFrameSourceLink(getComponentsStackDump());
         // xxxFlorent: should be reverted if we integrate 
         // https://github.com/fflorent/firebug/commit/d5c65e8 (related to issue6268)
-        if (DebuggerLib.isFrameLocationEval(sourceLink.href))
+        if (sourceLink && DebuggerLib.isFrameLocationEval(sourceLink.href))
             return null;
         return sourceLink;
     }


### PR DESCRIPTION
sourceLink is null when all the callers in the stack dump have system urls (e.g. chrome:// and resource://):

https://github.com/firebug/firebug/blob/master/extension/content/firebug/console/consoleExposed.js#L381

and logFormatted raise an exception.

Raising an exception currently prevents javascript code injected from a content-script to use the Firebug console object to print logs, and content-scripts are commonly used by Firefox Add-ons based on Addon SDK to interact with a content page (as in tildeio/ember-extension#94)
