### PR TITLE
fix for Xpath.getElementTreeXPath

### DIFF
--- a/extension/content/firebug/lib/xpath.js
+++ b/extension/content/firebug/lib/xpath.js
@@ -31,11 +31,10 @@ Xpath.getElementTreeXPath = function(element)
     var paths = [];
 
     // Use nodeName (instead of localName) so namespace prefix is included (if any).
-    for (; element && element.nodeType == Node.ELEMENT_NODE; element = element.parentNode)
-    {
-        var index = 0;
-        for (var sibling = element.previousSibling; sibling; sibling = sibling.previousSibling)
-        {
+    for (; element && element.nodeType == Node.ELEMENT_NODE; element = element.parentNode) {
+        var index = 0,
+            hasFollowingSiblings = false;
+        for (var sibling = element.previousSibling; sibling; sibling = sibling.previousSibling) {
             // Ignore document type declaration.
             if (sibling.nodeType == Node.DOCUMENT_TYPE_NODE)
                 continue;
@@ -44,8 +43,13 @@ Xpath.getElementTreeXPath = function(element)
                 ++index;
         }
 
+        for (var sibling = element.nextSibling; sibling && !hasFollowingSiblings; sibling = sibling.nextSibling) {
+            if (sibling.nodeName == element.nodeName)
+            	hasFollowingSiblings = true;
+        }
+
         var tagName = (element.prefix ? element.prefix + ":" : "") + element.localName;
-        var pathIndex = (index ? "[" + (index+1) + "]" : "");
+        var pathIndex = (index || hasFollowingSiblings ? "[" + (index + 1) + "]" : "");
         paths.splice(0, 0, tagName + pathIndex);
     }
 


### PR DESCRIPTION
I came accross this issue when I reused getElementTreeXPath() functionality in my project

Case:

  Incorrect Xpath string returned if element has siblings of same node name when traversing element node tree

Example (how to reproduce):

  Using Firebug's "Copy XPath" when right clicking on element in document's element tree.

  Let's say we have we have a HTML document with this structure, where X is the element we're trying to get XPath of:
- html
  -- body
  --- div
  ---- div [X]
  ---- div
  
  XPath returned: /html/body/div/div (should be /html/body/div/div[1])
