### PR TITLE
issue 6341

### DIFF
--- a/extension/content/firebug/html/layout.js
+++ b/extension/content/firebug/html/layout.js
@@ -65,7 +65,10 @@ LayoutPanel.prototype = Obj.extend(Panel,
                             Locale.$STR("a11y.layout.box-sizing") + ": " + "$boxSizing"),
                         SPAN({"class": "layoutZIndex", $invisible: "$zIndex|isInvisible",
                                 "aria-label": Locale.$STR("a11y.layout.z-index")},
-                            "z: " + "$zIndex")
+                            "z: " + "$zIndex"), 	 
+                        SPAN({"class": "layoutDisplay layoutCaption", 	
+                                "aria-label": Locale.$STR("a11y.layout.display")},
+                            "display: " + "$display")
                     ),
 
                     DIV({"class": "layoutLabelTop layoutLabel",
@@ -335,6 +338,7 @@ LayoutPanel.prototype = Obj.extend(Panel,
 
         var position = style.getPropertyCSSValue("position").cssText;
         args.position = position;
+        args.display = style.getPropertyCSSValue("display").cssText;
         args.outerLabel = "";
 
         if (Xml.isElementSVG(element) || Xml.isElementMathML(element) || Xml.isElementXUL(element))
@@ -387,6 +391,7 @@ LayoutPanel.prototype = Obj.extend(Panel,
                 layoutBoxSizing: {label: Locale.$STR("a11y.layout.box-sizing"),
                     value: "boxSizing"},
                 layoutZIndex: {label: "z", value: "zIndex"},
+                layoutDisplay: {label: "display", value: "display"},
                 layoutLabelOuterTop: {value: "outerTop"},
                 layoutLabelOuterRight: {value: "outerRight"},
                 layoutLabelOuterBottom: {value: "outerBottom"},

--- a/extension/locale/en-US/firebug.properties
+++ b/extension/locale/en-US/firebug.properties
@@ -1354,6 +1354,7 @@ a11y.layout.width=width
 a11y.layout.height=height
 a11y.layout.size=size
 a11y.layout.z-index=z-index
+a11y.layout.display=display
 a11y.layout.box-sizing=box-sizing
 a11y.layout.clientBoundingRect=bounding client rect
 a11y.descriptions.press_enter_to_edit_values=Press Enter followed by Tab to edit individual values

--- a/extension/skin/classic/layout.css
+++ b/extension/skin/classic/layout.css
@@ -102,7 +102,8 @@
 
 .layoutLabelPosition,
 .layoutBoxSizing,
-.layoutZIndex {
+.layoutZIndex,
+.layoutDisplay {
     display: block;
 }
 
@@ -118,6 +119,9 @@
 
 .layoutZIndex {
     float: right;
+}
+.layoutDisplay {    
+    left: 90px;
 }
 
 .layoutLabelLeft {


### PR DESCRIPTION
> when I resize Firebug to make it vertically smaller, the "display" entry disappears out of view
> Agree.
> 
> I wonder if we should have both display and box-sizing in the middle, while z-index 
> and position occupy one side each. It looks a little weird. Sebastian?
> Agree.
> 
> Maybe we can put it above box-sizing
> Also agree.
> 
> and the measurements should hopefully not change with locale since all strings are CSS keywords.
> I wonder if we should actually have translation keys for that. But that's also out of the scope of this issue.

So Edvard, could you please fix the three little issues mentioned above before we merge this? The rest seems to be fine
