### PR TITLE
Fix Events panel breakage

### DIFF
--- a/extension/content/firebug/html/eventsPanel.js
+++ b/extension/content/firebug/html/eventsPanel.js
@@ -406,7 +406,7 @@ EventsPanel.prototype = Obj.extend(Firebug.Panel,
     getListeners: function(target)
     {
         var normal = this.getNormalEventListeners(target);
-        var disabled = this.getDisabledMap(this.context).get(target, []);
+        var disabled = this.getDisabledMap(this.context).get(target) || [];
 
         // Try to insert the disabled listeners at their previous positions. This will be
         // wrong in case listeners have been removed since those positions were recorded,


### PR DESCRIPTION
Not sure what issue tracker to use any more, but this fixes obvious breakage in the Events panel in Firefox 38+ (due to https://bugzilla.mozilla.org/show_bug.cgi?id=1127827).
