### PR TITLE
Stop using "box-sizing: padding-box"

### DIFF
--- a/extension/content/firebug/lib/css.js
+++ b/extension/content/firebug/lib/css.js
@@ -1254,7 +1254,6 @@ Css.cssKeywords =
 
     "boxModels":
     [
-        "padding-box",
         "border-box",
         "content-box"
     ],

--- a/extension/skin/classic/console.css
+++ b/extension/skin/classic/console.css
@@ -804,7 +804,7 @@ of an error log is affected (higher than other logs). */
 .spyTitle {
     color: #000000;
     font-weight: bold;
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     overflow: hidden;
     z-index: 100;
     padding-left: 18px;

--- a/extension/skin/classic/cookies/cookies.css
+++ b/extension/skin/classic/cookies/cookies.css
@@ -294,7 +294,7 @@
 /************************************************************************************************/
 
 .cookieNameLabel {
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     overflow: hidden;
     padding-top: 1px;
     font-weight: bold;

--- a/extension/skin/classic/html.css
+++ b/extension/skin/classic/html.css
@@ -1,7 +1,7 @@
 /* See license.txt for terms of usage */
 
 .panelNode-html {
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     padding: 4px 0 0 2px;
     word-wrap: break-word;
 }

--- a/extension/skin/classic/net.css
+++ b/extension/skin/classic/net.css
@@ -233,7 +233,7 @@
 }
 
 .netHrefLabel {
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     overflow: hidden;
     z-index: 10;
     position: absolute;
@@ -402,7 +402,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 .netTimeLabel {
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     position: absolute;
     top: 1px;
     left: 100%;

--- a/extension/skin/classic/net.css
+++ b/extension/skin/classic/net.css
@@ -248,7 +248,7 @@
     display: none;
     -moz-user-select: none;
     padding-right: 10px;
-    padding-bottom: 2px;
+    padding-bottom: 3px;
     max-width: calc(100% - 38px);
     background: #FFFFFF;
     z-index: 200;

--- a/extension/skin/classic/performanceTiming.css
+++ b/extension/skin/classic/performanceTiming.css
@@ -23,7 +23,7 @@
 }
 
 .perfTimingBarLabel {
-    -moz-box-sizing: padding-box;
+    box-sizing: border-box;
     position: absolute;
     top: 1px;
     left: 100%;


### PR DESCRIPTION
Since support was removed in https://bugzilla.mozilla.org/show_bug.cgi?id=1166728. Rather unimportant commit, since I don't see any immediate visual differences, but hey.

Also fixes a 0.5px alignment issue when hovering lines in the Net panel. Could be worth confirming that it doesn't break anything on Windows.
