### PR TITLE
Remove usages of non-standard method "".replace(_, _, flags)

### DIFF
--- a/extension/content/firebug/lib/domplate.js
+++ b/extension/content/firebug/lib/domplate.js
@@ -868,7 +868,7 @@ function parseParts(str)
     if (!index)
     {
         // Double quotes in strings need to be escaped (see issue 6710)
-        return str.replace("\\", "\\\\", "g").replace('"', '\\"', "g");
+        return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
     }
 
     // If we have data after our last matched index we append it here as the final step

--- a/extension/content/firebug/lib/string.js
+++ b/extension/content/firebug/lib/string.js
@@ -406,8 +406,8 @@ Str.stripNewLines = function(value)
 
 Str.escapeSingleQuoteJS = function(value)
 {
-    return value.replace("\\", "\\\\", "g").replace(/\r/gm, "\\r")
-                .replace(/\n/gm, "\\n").replace("'", "\\'", "g");
+    return value.replace(/\\/g, "\\\\").replace(/\r/gm, "\\r")
+                .replace(/\n/gm, "\\n").replace(/'/g, "\\'");
 };
 
 Str.reverseString = function(value)
@@ -417,8 +417,8 @@ Str.reverseString = function(value)
 
 Str.escapeJS = function(value)
 {
-    return value.replace("\\", "\\\\", "g").replace(/\r/gm, "\\r")
-        .replace(/\n/gm, "\\n").replace('"', '\\"', "g");
+    return value.replace(/\\/g, "\\\\").replace(/\r/gm, "\\r")
+        .replace(/\n/gm, "\\n").replace(/"/g, '\\"');
 };
 
 Str.cropString = function(text, limit, alternativeText)

--- a/extension/content/firebug/lib/url.js
+++ b/extension/content/firebug/lib/url.js
@@ -343,9 +343,7 @@ Url.isAbsoluteUrl = function(url)
 
 Url.absoluteURL = function(url, baseURL)
 {
-    // Replace "/./" with "/" using regular expressions (don't use string since /./
-    // can be treated as regular expressoin too, see 3551).
-    return Url.absoluteURLWithDots(url, baseURL).replace(/\/\.\//, "/", "g");
+    return Url.absoluteURLWithDots(url, baseURL).replace(/\/\.\//g, "/");
 };
 
 Url.absoluteURLWithDots = function(url, baseURL)

--- a/extension/modules/locale.js
+++ b/extension/modules/locale.js
@@ -65,7 +65,7 @@ Locale.$STR = function(name, bundle)
     if (!name)
         return "";
 
-    var strKey = name.replace(" ", "_", "g");
+    var strKey = name.replace(/ /g, "_");
 
     if (!PrefLoader.getPref("useDefaultLocale"))
     {
@@ -100,14 +100,14 @@ Locale.$STR = function(name, bundle)
     var index = name.lastIndexOf(".");
     if (index > 0 && name.charAt(index-1) != "\\")
         name = name.substr(index + 1);
-    name = name.replace("_", " ", "g");
+    name = name.replace(/_/g, " ");
 
     return name;
 };
 
 Locale.$STRF = function(name, args, bundle)
 {
-    var strKey = name.replace(" ", "_", "g");
+    var strKey = name.replace(/ /g, "_");
 
     if (!PrefLoader.getPref("useDefaultLocale"))
     {

--- a/extension/modules/require-debug.js
+++ b/extension/modules/require-debug.js
@@ -67,8 +67,7 @@ require.execCbOFF = function (name)
                             (typeof value == "function"/* || typeof value == "object"*/))
                         {
                                 var funcName = name + "_" + prop;
-                                funcName = funcName.replace("/", "_", "g");
-                                funcName = funcName.replace("-", "_", "g");
+                                funcName = funcName.replace(/[\/\-]/g, "_");
                                 var namedFunction = eval("(function(){ return function " + funcName +
                                     "(){return true;} })()");
                                 value.displayName = namedFunction;


### PR DESCRIPTION
Eventually planned for removal in https://bugzilla.mozilla.org/show_bug.cgi?id=1108382. (But no hurry.)
