### PR TITLE
Cope with renamed API evalInGlobal -> executeInGlobal (bug 1193583)

### DIFF
--- a/extension/content/firebug/console/commandLineExposed.js
+++ b/extension/content/firebug/console/commandLineExposed.js
@@ -237,8 +237,8 @@ function evaluateInGlobal(context, win, expr, origExpr, onSuccess, onError, opti
 {
     var dbgGlobal = DebuggerLib.getInactiveDebuggeeGlobal(context, win);
     var evalMethod = options.noCmdLineAPI ?
-                     dbgGlobal.evalInGlobal :
-                     dbgGlobal.evalInGlobalWithBindings;
+                     (dbgGlobal.executeInGlobal || dbgGlobal.evalInGlobal) :
+                     (dbgGlobal.executeInGlobalWithBindings || dbgGlobal.evalInGlobalWithBindings);
 
     var args = [dbgGlobal, evalMethod, dbgGlobal];
     args.push.apply(args, arguments);
@@ -528,8 +528,11 @@ function executeInWindowContext(win, func, args, dbgGlobal)
     var code = "(function() { callback(); })";
     var bindings = Object.create(null);
     bindings.callback = dbgGlobal.makeDebuggeeValue(listener);
-    var listenerInWindow = dbgGlobal.evalInGlobalWithBindings(code, bindings)
-        .return.unsafeDereference();
+    var listenerInWindow = (
+            dbgGlobal.executeInGlobalWithBindings ?
+            dbgGlobal.executeInGlobalWithBindings(code, bindings) :
+            dbgGlobal.evalInGlobalWithBindings(code, bindings)
+        ).return.unsafeDereference();
 
     win.document.addEventListener("firebugCommandLine", listenerInWindow);
 

--- a/extension/content/firebug/debugger/debuggerLib.js
+++ b/extension/content/firebug/debugger/debuggerLib.js
@@ -552,7 +552,9 @@ DebuggerLib.breakNow = function(context)
         // but we might want to change what global to use here.
         var global = context.getCurrentGlobal();
         var dbgGlobal = this.getInactiveDebuggeeGlobal(context, global);
-        return dbgGlobal.evalInGlobal("debugger;");
+        return dbgGlobal.executeInGlobal ?
+            dbgGlobal.executeInGlobal("debugger;") :
+            dbgGlobal.evalInGlobal("debugger;");
     }
 };
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1193583 will land soon on Nightly, and break the command line and parts of the debugger. Untested.
