### PR TITLE
Fix webconsole/utils path for nightly

### DIFF
--- a/extension/content/firebug/console/console.js
+++ b/extension/content/firebug/console/console.js
@@ -32,7 +32,17 @@ function(Firebug, FBTrace, Obj, Events, Locale, Search, Wrapper, Xml, Options, W
 
 var Cu = Components.utils;
 var scope = Cu.import("resource://gre/modules/devtools/Loader.jsm", {});
-var {ConsoleAPIListener} = scope.devtools.require("devtools/toolkit/webconsole/utils");
+var ConsoleAPIListener;
+
+try {
+    ConsoleAPIListener =
+        scope.devtools.require("devtools/toolkit/webconsole/utils").ConsoleAPIListener;
+}
+catch (ex) {
+    ConsoleAPIListener =
+        scope.devtools.require("devtools/shared/webconsole/utils").ConsoleAPIListener;
+}
+
 
 var defaultReturnValue = Object.preventExtensions(Object.create(null));
 


### PR DESCRIPTION
Firebug does not open in the latest nightly builds. This fixes the path for the webconsole/utils path.

I can take more time to identify other broken paths. But at least I think we should commit this fix (which sounds the most critical).

Florent
