### PR TITLE
 #7948 Fix "href is null" appearing in the console

### DIFF
--- a/extension/content/firebug/debugger/stack/stackFrame.js
+++ b/extension/content/firebug/debugger/stack/stackFrame.js
@@ -354,7 +354,7 @@ StackFrame.removeChromeFrames = function(trace)
     for (var i = 0; i < frames.length; i++)
     {
         var href = frames[i].href;
-        if (href.startsWith("chrome:") || href.startsWith("resource:"))
+        if (href && (href.startsWith("chrome:") || href.startsWith("resource:")))
             continue;
 
         // xxxFlorent: should be reverted if we integrate


### PR DESCRIPTION
The backend may send a null source location in for a frame.

Because of this:
https://hg.mozilla.org/mozilla-central/annotate/9169f652fe5e69c2d77ac31929934a5bc3342e6e/devtools/server/actors/utils/TabSources.js#l276

Note: I suspect there may be other impacts when href is null. Though I can't identify them...

Florent
