### PR TITLE
#7954 Many evaluated expression are listed in the script panel

### DIFF
--- a/extension/content/firebug/debugger/script/sourceTool.js
+++ b/extension/content/firebug/debugger/script/sourceTool.js
@@ -155,7 +155,8 @@ SourceTool.prototype = Obj.extend(new Tool(),
     {
         // Ignore scripts generated from 'clientEvaluate' packets. These scripts are
         // created e.g. as the user is evaluating expressions in the watch window.
-        if (DebuggerLib.isFrameLocationEval(script.url))
+        if (script.introductionType === "debugger eval" ||
+            DebuggerLib.isFrameLocationEval(script.url))
         {
             Trace.sysout("sourceTool.addScript; A script ignored " + script.type +
                 ", " + script.url, script);


### PR DESCRIPTION
It sounds like there is a new introductionType for scripts evaluated in the Console. 

I checked the other call sites of `DebuggerLib.isFrameLocationEval` and it appeared to me it wasn't relevant to test also there. But feel free to check by yourself.

Florent
