### PR TITLE
#8000 Firebug doesn't work on nightly 48 (deprecated APIs)

### DIFF
--- a/extension/content/firebug/firefox/browserOverlay.js
+++ b/extension/content/firebug/firefox/browserOverlay.js
@@ -38,6 +38,7 @@ Locale.registerStringBundle("chrome://firebug/locale/multiprocess-notification.p
 Cu.import("resource://firebug/loader.js");
 Cu.import("resource://firebug/fbtrace.js");
 Cu.import("resource://gre/modules/AddonManager.jsm");
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
 var servicesScope = {};
 Cu.import("resource://gre/modules/Services.jsm", servicesScope);
@@ -449,15 +450,11 @@ BrowserOverlay.prototype =
 
         var loadingPrincipal = servicesScope.Services.scriptSecurityManager.getSystemPrincipal();
 
-        var channel = ioService.newChannel2(
-            versionURL,
-            /* aOriginCharset */null,
-            /* aBaseURI */ null,
-            /* aLoadingNode */null,
-            loadingPrincipal,
-            /* aTriggeringPrincipal */ null,
-            /* aSecurityFlag */ Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL,
-            /* aContentPolicyType */ Ci.nsIContentPolicy.TYPE_OTHER);
+        var channel = NetUtil.newChannel({
+            uri: versionURL,
+            loadUsingSystemPrincipal: true
+        });
+
         var input = channel.open();
         var sis = Cc["@mozilla.org/scriptableinputstream;1"].
             createInstance(Ci.nsIScriptableInputStream);

--- a/extension/content/firebug/firefox/browserOverlay.js
+++ b/extension/content/firebug/firefox/browserOverlay.js
@@ -447,7 +447,17 @@ BrowserOverlay.prototype =
         var versionURL = "chrome://firebug/content/branch.properties";
         var ioService = Cc["@mozilla.org/network/io-service;1"].getService(Ci.nsIIOService);
 
-        var channel = ioService.newChannel(versionURL, null, null);
+        var loadingPrincipal = servicesScope.Services.scriptSecurityManager.getSystemPrincipal();
+
+        var channel = ioService.newChannel2(
+            versionURL,
+            /* aOriginCharset */null,
+            /* aBaseURI */ null,
+            /* aLoadingNode */null,
+            loadingPrincipal,
+            /* aTriggeringPrincipal */ null,
+            /* aSecurityFlag */ Ci.nsILoadInfo.SEC_ALLOW_CROSS_ORIGIN_DATA_IS_NULL,
+            /* aContentPolicyType */ Ci.nsIContentPolicy.TYPE_OTHER);
         var input = channel.open();
         var sis = Cc["@mozilla.org/scriptableinputstream;1"].
             createInstance(Ci.nsIScriptableInputStream);

--- a/extension/content/firebug/lib/http.js
+++ b/extension/content/firebug/lib/http.js
@@ -92,11 +92,22 @@ Http.readPostTextFromPage = function(url, context)
      }
 };
 
-Http.getResource = function(aURL, ignoreMissing)
+Http.getResource = function(aURL, ignoreMissing, doc)
 {
+    if (!doc) {
+        doc = Firebug.chrome.window.document;
+    }
     try
     {
-        var channel = ioService.newChannel(aURL, null, null);
+        var channel = ioService.newChannel2(
+            aURL,
+            /* aCharset */ null,
+            /* aBaseURI */ null,
+            /* aLoadingNode */ doc,
+            /* aLoadingPrincipal */ null,
+            /* aTriggeringPrincipal */ null,
+            /* aSecurityFlag */ null,
+            /* aContentPolicyType */ null);
         var input = channel.open();
 
         return Http.readFromStream(input);

--- a/extension/content/firebug/lib/http.js
+++ b/extension/content/firebug/lib/http.js
@@ -17,9 +17,12 @@ function(Xpcom, FBTrace, Deprecated, StackFrame, Str) {
 const Cc = Components.classes;
 const Ci = Components.interfaces;
 const Cr = Components.results;
+const Cu = Components.utils;
 
 const NS_SEEK_SET = Ci.nsISeekableStream.NS_SEEK_SET;
 const ioService = Cc["@mozilla.org/network/io-service;1"].getService(Ci.nsIIOService);
+
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
 var Http = {};
 
@@ -92,22 +95,15 @@ Http.readPostTextFromPage = function(url, context)
      }
 };
 
-Http.getResource = function(aURL, ignoreMissing, doc)
+Http.getResource = function(aURL, ignoreMissing)
 {
-    if (!doc) {
-        doc = Firebug.chrome.window.document;
-    }
     try
     {
-        var channel = ioService.newChannel2(
-            aURL,
-            /* aCharset */ null,
-            /* aBaseURI */ null,
-            /* aLoadingNode */ doc,
-            /* aLoadingPrincipal */ null,
-            /* aTriggeringPrincipal */ null,
-            /* aSecurityFlag */ null,
-            /* aContentPolicyType */ null);
+        var channel = NetUtil.newChannel({
+            uri: aURL,
+            loadUsingSystemPrincipal: true
+        });
+
         var input = channel.open();
 
         return Http.readFromStream(input);

--- a/extension/content/firebug/net/sourceCache.js
+++ b/extension/content/firebug/net/sourceCache.js
@@ -17,6 +17,8 @@ function(EventSource, Obj, Firebug, Xpcom, Url, Http, Options, Str) {
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
+const Cu = Components.utils;
+
 const nsIIOService = Ci.nsIIOService;
 const nsIRequest = Ci.nsIRequest;
 const nsICachingChannel = Ci.nsICachingChannel;
@@ -33,6 +35,8 @@ const LOAD_FROM_CACHE = nsIRequest.LOAD_FROM_CACHE;
 const LOAD_BYPASS_LOCAL_CACHE_IF_BUSY = nsICachingChannel.LOAD_BYPASS_LOCAL_CACHE_IF_BUSY;
 
 const NS_BINDING_ABORTED = 0x804b0002;
+
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
 // ********************************************************************************************* //
 
@@ -214,8 +218,11 @@ Firebug.SourceCache.prototype = Obj.extend(new EventSource(),
         var channel;
         try
         {
-            // TODO use newChannel2 here
-            channel = ioService.newChannel(url, null, null);
+            channel = NetUtil.newChannel({
+                uri: url,
+                loadUsingSystemPrincipal: true
+            });
+
             channel.loadFlags |= LOAD_FROM_CACHE | LOAD_BYPASS_LOCAL_CACHE_IF_BUSY;
 
             if (method && (channel instanceof nsIHttpChannel))

--- a/extension/content/firebug/net/sourceCache.js
+++ b/extension/content/firebug/net/sourceCache.js
@@ -214,6 +214,7 @@ Firebug.SourceCache.prototype = Obj.extend(new EventSource(),
         var channel;
         try
         {
+            // TODO use newChannel2 here
             channel = ioService.newChannel(url, null, null);
             channel.loadFlags |= LOAD_FROM_CACHE | LOAD_BYPASS_LOCAL_CACHE_IF_BUSY;
 

--- a/extension/content/firebug/net/tabCache.js
+++ b/extension/content/firebug/net/tabCache.js
@@ -440,6 +440,7 @@ Firebug.TabCache.prototype = Obj.extend(SourceCache.prototype,
             if (url === "<unknown>")
                 return [Locale.$STR("message.sourceNotAvailableFor") + ": " + url];
 
+            // TODO use newChannel2 here
             var channel = ioService.newChannel(url, null, null);
 
             // These flag combination doesn't repost the request.

--- a/extension/content/firebug/net/tabCache.js
+++ b/extension/content/firebug/net/tabCache.js
@@ -27,8 +27,11 @@ function(ActivableModule, Obj, Firebug, Xpcom, HttpRequestObserver, HttpResponse
 
 const Cc = Components.classes;
 const Ci = Components.interfaces;
+const Cu = Components.utils;
 
 const ioService = Cc["@mozilla.org/network/io-service;1"].getService(Ci.nsIIOService);
+
+Cu.import("resource://gre/modules/NetUtil.jsm");
 
 // List of text content types. These content-types are cached.
 var contentTypes =
@@ -440,8 +443,10 @@ Firebug.TabCache.prototype = Obj.extend(SourceCache.prototype,
             if (url === "<unknown>")
                 return [Locale.$STR("message.sourceNotAvailableFor") + ": " + url];
 
-            // TODO use newChannel2 here
-            var channel = ioService.newChannel(url, null, null);
+            var channel = NetUtil.newChannel({
+                uri: url,
+                loadUsingSystemPrincipal: true
+            });
 
             // These flag combination doesn't repost the request.
             channel.loadFlags = Ci.nsIRequest.LOAD_FROM_CACHE |

--- a/extension/modules/firebug-trace-service.js
+++ b/extension/modules/firebug-trace-service.js
@@ -138,8 +138,7 @@ TracerWrapper.prototype =
 
         // Create FBTrace proxy. As soon as FBTrace console is available it'll forward
         // all calls to it.
-        return Proxy.create(
-        {
+        return new Proxy({}, {
             get: function(target, name)
             {
                 return self.FBTrace ? self.FBTrace[name] : self.tracer[name];

--- a/extension/modules/firebug-trace-service.js
+++ b/extension/modules/firebug-trace-service.js
@@ -138,7 +138,8 @@ TracerWrapper.prototype =
 
         // Create FBTrace proxy. As soon as FBTrace console is available it'll forward
         // all calls to it.
-        return new Proxy({}, {
+        return new Proxy({},
+        {
             get: function(target, name)
             {
                 return self.FBTrace ? self.FBTrace[name] : self.tracer[name];


### PR DESCRIPTION
Replace deprecated APIs to work with nightly 48. There are some places where I am not sure about the transition from `newChannel` to `newChannel2`.

@janodvarko Don't hesitate to complete the commit.

Florent
