### PR TITLE
Check if the browser is e10s before displaying the firebugInspect menu

### DIFF
--- a/extension/content/firebug/firefox/browserMenu.js
+++ b/extension/content/firebug/firefox/browserMenu.js
@@ -435,16 +435,19 @@ var BrowserMenu =
 
     overlayFirefoxMenu: function(doc)
     {
-        // Firefox page context menu
-        $menupopupOverlay(doc, $(doc, "contentAreaContextMenu"), [
-            $menuseparator(doc),
-            $menuitem(doc, {
-                id: "menu_firebug_firebugInspect",
-                label: "firebug.InspectElementWithFirebug",
-                command: "cmd_firebug_inspect",
-                "class": "menuitem-iconic"
-            })
-        ]);
+        // Firefox page context menu (only in non-multi-process mode, to avoid confusion).
+        if (!this.browserOverlay.isMultiprocessEnabled())
+        {
+            $menupopupOverlay(doc, $(doc, "contentAreaContextMenu"), [
+                $menuseparator(doc),
+                $menuitem(doc, {
+                    id: "menu_firebug_firebugInspect",
+                    label: "firebug.InspectElementWithFirebug",
+                    command: "cmd_firebug_inspect",
+                    "class": "menuitem-iconic"
+                })
+            ]);
+        }
 
         // Firefox view menu
         $menupopupOverlay(doc, $(doc, "menu_viewPopup"),


### PR DESCRIPTION
Just a simple `if (!isMultiprocessEnabled)` around the code that adds the menu popup overlay.
This fixes #8077 for me, I have tested with and without multi-process enabled.

How does that look @janodvarko 